### PR TITLE
cis-gendered => cisgender

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ layout: default
 
 <h2 id="contribute">Contribute to this guide</h2>
 
-<p>This is just the beginning. I am a cis-gendered black woman and my voice should not be the only one contributing to this guide.</p>
+<p>This is just the beginning. I am a cisgender black woman and my voice should not be the only one contributing to this guide.</p>
 
 <p>If you identify as a membr of a marginalized group and want to contribute, please submit a pull-request on the GitHub repository <a href="https://github.com/almnt/guide-to-allyship" target="_blank">here.</a></p>
 


### PR DESCRIPTION
Dropping the `ed` is because cisgender is a noun, not a verb. Dropping the `-` is just keeping in line with common usage so you don't seem out of touch