### PR TITLE
Add notes about speaking for/over vs amplifying marginalized voices

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@ layout: default
       <li><strong>Do not</strong> behave as though you know best</li>
       <li><strong>Do not</strong> take credit for the labor of those who are marginalized and did the work before you stepped into the picture</li>
       <li><strong>Do not</strong> assume that every member of a marginalized group feels oppressed</li>
+      <li><strong>Do not</strong> presume to speak for members of marginalized groups</li>
     </ul>
   </div>
 
@@ -96,6 +97,7 @@ layout: default
       <li><strong>Do</strong> your research to learn more about the history of the struggle in which you are participating</li>
       <li><strong>Do</strong> the inner work to figure out a way to acknowledge how you participate in oppressive systems</li>
       <li><strong>Do</strong> the outer work and figure out how to change the oppressive systems</li>
+      <li><strong>Do</strong> use your position and platform to amplify marginalized voices</li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This has been one of the biggest learning points for me. As a white cis man, it's easy for me to just take up space in discussions that should be occupied by marginalised voices. And those voices are out there: I just need to actively search for them and amplify them instead of contributing my own voice and my own thoughts (which are outside of the experience and therefore irrelevant to the discussion, no matter how well-intentioned).