### PR TITLE
Privilege Transfer and Ally Amplification

### DIFF
--- a/_includes/being-an-ally.html
+++ b/_includes/being-an-ally.html
@@ -3,6 +3,7 @@
   <h2>To be an <span>ally</span> is to...</h2>
     <p>Take on the struggle as your own.</p>
     <p>Stand up, even when you feel scared.</p>
+    <p>Transfer the benefits of your privilege to those who lack it.</p>
     <p>Acknowledge that while you, too, feel pain, the conversation is not about you.</p>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@ layout: default
       <li><strong>Do</strong> your research to learn more about the history of the struggle in which you are participating</li>
       <li><strong>Do</strong> the inner work to figure out a way to acknowledge how you participate in oppressive systems</li>
       <li><strong>Do</strong> the outer work and figure out how to change the oppressive systems</li>
+      <li><strong>Do</strong> amplify (online and when physically present) the voices of those without your privilege </li>
     </ul>
   </div>
 </div>
@@ -106,6 +107,6 @@ layout: default
 
 <p>This is just the beginning. I am a cis-gendered black woman and my voice should not be the only one contributing to this guide.</p>
 
-<p>If you identify as a membr of a marginalized group and want to contribute, please submit a pull-request on the GitHub repository <a href="https://github.com/almnt/guide-to-allyship" target="_blank">here.</a></p>
+<p>If you identify as a member of a marginalized group and want to contribute, please submit a pull-request on the GitHub repository <a href="https://github.com/almnt/guide-to-allyship" target="_blank">here.</a></p>
 
 <p>If you aren’t a user of GitHub, shoot me an email at <a href="mailto:guidetoallyship@gmail.com" target="_blank">guidetoallyship@gmail.com</a></p>


### PR DESCRIPTION
Hi Amélie,

I'm suggesting three changes:
1. Added the concept of "transferring privilege" to the being-an-ally.html file. I have found that transferring the benefits of privilege (gender privilege, racial privilege, physical privilege, etc.) is an important concept for allies to understand. By the way, I described this in more detail in a talk I gave at GitHub Universe last week called "Lending Privilege":  http://www.ustream.tv/recorded/91346697
2. I also added to the "Do" list the concept of "ally amplification" on the index.html file. I've found that allies often don't know how to start their allyship. One thing that allies can do _today_ is to amplify the voices of the groups they want to help. For example, allies with male privilege can make sure that the women in their organizations have their voices heard in meetings, projects, and promotion discussions. Also, male allies (especially those with large followers) can amplify the voices of women on Twitter by replying and retweeting them.
3. I fixed a small typo on the index.html file by changing "membr" to "member".

Of course, I totally defer to your judgement about whether to merge these suggestions in or not. I think this guide is great! Let me know if I can help in any other way.

Regards,

Anjuan
