### PR TITLE
Swap don't's and do's order to be positive-first

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,17 +78,6 @@ layout: default
 <p>Just as society will not change overnight, neither will you. Here are some do’s and don’ts that are incredibly important as you learn and grow and step into the role of an ally.</p>
 
 <div class="donts-and-dos">
-  <div class="donts">
-    <h3>The Don’ts</h3>
-    <ul>
-      <li><strong>Do not</strong> expect to be taught or shown. Take it upon yourself to use the tools around you to learn and answer your questions</li>
-      <li><strong>Do not</strong> participate for the gold medal in the Oppression Olympics</li>
-      <li><strong>Do not</strong> behave as though you know best</li>
-      <li><strong>Do not</strong> take credit for the labor of those who are marginalized and did the work before you stepped into the picture</li>
-      <li><strong>Do not</strong> assume that every member of a marginalized group feels oppressed</li>
-    </ul>
-  </div>
-
   <div class="dos">
     <h3>The Do’s</h3>
     <ul>
@@ -98,6 +87,17 @@ layout: default
       <li><strong>Do</strong> the inner work to figure out a way to acknowledge how you participate in oppressive systems</li>
       <li><strong>Do</strong> the outer work and figure out how to change the oppressive systems</li>
       <li><strong>Do</strong> amplify (online and when physically present) the voices of those without your privilege</li>
+    </ul>
+  </div>
+  
+  <div class="donts">
+    <h3>The Don’ts</h3>
+    <ul>
+      <li><strong>Do not</strong> expect to be taught or shown. Take it upon yourself to use the tools around you to learn and answer your questions</li>
+      <li><strong>Do not</strong> participate for the gold medal in the Oppression Olympics</li>
+      <li><strong>Do not</strong> behave as though you know best</li>
+      <li><strong>Do not</strong> take credit for the labor of those who are marginalized and did the work before you stepped into the picture</li>
+      <li><strong>Do not</strong> assume that every member of a marginalized group feels oppressed</li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This is a suggested change to put the Do's of being a good ally first, and the Don't's second, so that people are first given a constructive, helpful and positive list, before being told what things not to do.  

It does not alter the contents of either list. 

(And now, also, it matches the sentence introducing the two lists: "Here are some do's and don'ts…")