### PR TITLE
replace the bit about "remove politics"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -188,7 +188,7 @@ layout: layouts/base.html
       <li><strong>Stop the pattern:</strong> be careful where you step in the future. When it comes to oppression, we want to actually change the “footwear” to get rid of privilege and oppression (sneakers for all!), but metaphors can only stretch so far!</li>
     </ul>
 
-    <p>Reacting in a fair and helpful way isn’t about learning arbitrary rules or being a doormat. When we take the politics out of it, it’s just the <em>reasonable</em> thing to do. Still, it’s hard to remember in the moment, because these issues are so charged in our society. As such, it may be helpful to reframe the situation so that you don’t feel defensive.</p>
+    <p>Reacting in a fair and helpful way isn’t about learning arbitrary rules or being a doormat. Rather, it's about restoring and maintaining dignity and respect for everyone involved - the person who is hurt, and you. Still, it’s hard to remember in the moment, because these issues are so charged in our society. As such, it may be helpful to reframe the situation so that you don’t feel defensive.</p>
 
     <p>You may have noticed it’s easier to handle being corrected about something you didn’t know if you’re grateful for and even open to the opportunity to learn rather than embarrassed to have been wrong. Being able to let go of your ego is an incredibly important skill to develop.</p>
 

--- a/src/index.html
+++ b/src/index.html
@@ -188,7 +188,7 @@ layout: layouts/base.html
       <li><strong>Stop the pattern:</strong> be careful where you step in the future. When it comes to oppression, we want to actually change the “footwear” to get rid of privilege and oppression (sneakers for all!), but metaphors can only stretch so far!</li>
     </ul>
 
-    <p>Reacting in a fair and helpful way isn’t about learning arbitrary rules or being a doormat. Rather, it's about restoring and maintaining dignity and respect for everyone involved - the person who is hurt, and you. Still, it’s hard to remember in the moment, because these issues are so charged in our society. As such, it may be helpful to reframe the situation so that you don’t feel defensive.</p>
+    <p>Reacting in a fair and equitable way isn’t about learning arbitrary rules or being a doormat. Rather, it's about restoring and maintaining dignity and respect for everyone involved - both the person who is hurt, and you. Still, it’s hard to remember in the moment, because these issues are so charged in our society. As such, it may be helpful to reframe the situation so that you don’t feel defensive.</p>
 
     <p>You may have noticed it’s easier to handle being corrected about something you didn’t know if you’re grateful for and even open to the opportunity to learn rather than embarrassed to have been wrong. Being able to let go of your ego is an incredibly important skill to develop.</p>
 


### PR DESCRIPTION
hello - i noticed in the section on apologies that there was a mention of removing politics. i think i understand the intent here, to let go of politics for a moment when thinking about why we apologize. but the idea of removing politics bothers me for a lot of reasons - especially when considering recent events with Basecamp declaring their business as a no-politics area, and the massive problems this creates. 

i'd love to see the wording about removing politics removed from the guide and replaced with something less ambiguous. my suggestion in this PR is an idea that i had on what the wording may sound like, but i'm definitely open to any and all feedback around this and changes to the wording.